### PR TITLE
Fix previous fetch mailto and tel link

### DIFF
--- a/prefetcher.js
+++ b/prefetcher.js
@@ -30,9 +30,12 @@ export class Prefetcher {
     if (!href) return
     // skip anchor
     if (href.startsWith('#')) return
+    // skip mailto
+    if (href.startsWith('mailto:')) return
+    // skip tel
+    if (href.startsWith('tel:')) return
     // skip outside link
     if (href.includes("://") && !href.startsWith(window.location.origin)) return
-
     if (this.prefetched(href)) return
     if (this.prefetching(href)) return
     this.cleanup(event, href)


### PR DESCRIPTION
逛 `ruby-china` 的时候发现对邮件类型的 `a` 标签没有做过滤。