### PR TITLE
Shift target to nearest link if link is around an image

### DIFF
--- a/prefetcher.js
+++ b/prefetcher.js
@@ -18,7 +18,8 @@ export class Prefetcher {
   }
 
   mouseover(event) {
-    const { target } = event;
+    let { target } = event;
+    if (target instanceof HTMLImageElement) target = target.closest("a")
     if (!target) return
     if (target.hasAttribute('data-remote')) return
     if (target.hasAttribute('data-method')) return


### PR DESCRIPTION
Links around images are not properly picked up by `event.target`, resulting in those links not prefetching. This fixes that by checking if the target is an image, if it is shift the target from the image to the a tag surrounding it.

Example:
```
<a href="...">
  <img src"...">
</a>
```
Hovering the image (and as a result also the a tag) results in `event.target` being the image, rather than the link as we would want.